### PR TITLE
Build failed; edits to get it to build

### DIFF
--- a/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/TarCreate.java
+++ b/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/TarCreate.java
@@ -42,7 +42,7 @@ public class TarCreate extends PrimitiveFunction implements ReactiveFunction, Sp
             File f = new File(filename).getAbsoluteFile();
             try {
                 synchronized (zaos) {
-                    ArchiveEntry e = zaos.createArchiveEntry(f, entryName);
+                    TarArchiveEntry e = zaos.createArchiveEntry(f, entryName);
                     zaos.putArchiveEntry(e);
                     FileInputStream fis = new FileInputStream(f);
                     fis.transferTo(zaos);

--- a/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/TarSave.java
+++ b/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/TarSave.java
@@ -50,7 +50,7 @@ public class TarSave extends PrimitiveFunction implements Lambda {
             File f = new File(filename).getAbsoluteFile();
             try {
                 synchronized (zaos) {
-                    ArchiveEntry e = zaos.createArchiveEntry(f, entryName);
+                    TarArchiveEntry e = zaos.createArchiveEntry(f, entryName);
                     zaos.putArchiveEntry(e);
                     FileInputStream fis = new FileInputStream(f);
                     fis.transferTo(zaos);

--- a/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/ZipCreate.java
+++ b/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/ZipCreate.java
@@ -84,7 +84,7 @@ public class ZipCreate extends PrimitiveFunction implements ReactiveFunction, Sp
             File f = new File(filename).getAbsoluteFile();
             try {
                 synchronized (zaos) {
-                    ArchiveEntry e = zaos.createArchiveEntry(f, entryName);
+                    ZipArchiveEntry e = zaos.createArchiveEntry(f, entryName);
                     zaos.putArchiveEntry(e);
                     FileInputStream fis = new FileInputStream(f);
                     fis.transferTo(zaos);

--- a/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/ZipSave.java
+++ b/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/ZipSave.java
@@ -92,7 +92,7 @@ public class ZipSave extends PrimitiveFunction implements Lambda {
             File f = new File(filename).getAbsoluteFile();
             try {
                 synchronized (zaos) {
-                    ArchiveEntry e = zaos.createArchiveEntry(f, entryName);
+                    ZipArchiveEntry e = zaos.createArchiveEntry(f, entryName);
                     zaos.putArchiveEntry(e);
                     FileInputStream fis = new FileInputStream(f);
                     fis.transferTo(zaos);


### PR DESCRIPTION
I had trouble building, getting 4 errors.

I'm running:

```
$ mvn --version
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 17.0.10, vendor: Debian, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.10.0-28-amd64", arch: "amd64", family: "unix"

```
One of the errors:

```
$ mvn package
[..]
ERROR [..]/kamilalisp/src/main/java/palaiologos/kamilalisp/runtime/dataformat/archive/ZipCreate.java:
[88,42] incompatible types:
    org.apache.commons.compress.archivers.ArchiveEntry
cannot be converted to
    org.apache.commons.compress.archivers.zip.ZipArchiveEntry

```

My edit:

```
-                    ArchiveEntry e = zaos.createArchiveEntry(f, entryName);
+                    ZipArchiveEntry e = zaos.createArchiveEntry(f, entryName);

```
And similarly, edits in 3 other files, and it builds.

Is there something I could have done to have it build without these edits?
