### PR TITLE
Upgrade JLine to 3.26.1 and add jline-terminal-jni

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,21 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-reader</artifactId>
-            <version>3.24.1</version>
+            <version>3.26.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jline/jline-terminal -->
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal</artifactId>
-            <version>3.24.1</version>
+            <version>3.26.1</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.jline/jline-jni -->
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline-terminal-jni</artifactId>
+            <version>3.26.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.pcollections/pcollections -->

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             <version>3.26.1</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.jline/jline-jni -->
+        <!-- https://mvnrepository.com/artifact/org.jline/jline-terminal-jni -->
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jni</artifactId>

--- a/src/main/java/palaiologos/kamilalisp/repl/Main.java
+++ b/src/main/java/palaiologos/kamilalisp/repl/Main.java
@@ -70,7 +70,6 @@ public class Main {
                 .highlighter(new LispHighlight(env))
                 .variable(LineReader.SECONDARY_PROMPT_PATTERN, promptPattern)
                 .variable(LineReader.INDENTATION, 3)
-                .variable(LineReader.BLINK_MATCHING_PAREN, 0)
                 .terminal(t)
                 .completer(new LispCompletion(env))
                 .build();


### PR DESCRIPTION
I think the main problem is a missing dependency on a supported terminal on windows.
This should fix https://github.com/jline/jline3/issues/823
